### PR TITLE
Convert CloudFormation to Terraform

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,353 @@
+# REDCap on AWS - Terraform Infrastructure
+
+This Terraform configuration deploys a HIPAA-compliant REDCap (Research Electronic Data Capture) environment on AWS, replacing the original CloudFormation stack with modern EC2-based infrastructure.
+
+## Architecture Overview
+
+The infrastructure includes:
+
+- **VPC with 3-tier architecture** (public, application, database subnets)
+- **Application Load Balancer** with SSL termination
+- **Auto Scaling Group** with EC2 instances running Nginx + PHP-FPM
+- **RDS Aurora MySQL** cluster with encryption and backups
+- **S3 buckets** for file storage with encryption and lifecycle policies
+- **Route53 and ACM** for DNS and SSL certificate management
+- **CloudWatch** monitoring, logging, and alerting
+- **Systems Manager** for secure instance access
+
+## HIPAA Compliance Features
+
+- Encryption at rest and in transit
+- VPC isolation with security groups
+- Encrypted EBS volumes for logs
+- S3 bucket encryption with KMS
+- VPC Flow Logs for network monitoring
+- CloudWatch logging and monitoring
+- Access logging for all services
+
+## Prerequisites
+
+1. **AWS Account** with appropriate permissions
+2. **Terraform** >= 1.0 installed
+3. **AWS CLI** configured
+4. **REDCap Consortium membership** for downloading REDCap
+5. **SES configured** in your AWS account
+6. **Route53 hosted zone** (if using custom domain)
+
+## Quick Start
+
+### 1. Setup Terraform Backend
+
+First, create the S3 bucket and DynamoDB table for Terraform state:
+
+```bash
+# Create S3 bucket for Terraform state
+aws s3 mb s3://your-terraform-state-bucket
+
+# Create DynamoDB table for state locking
+aws dynamodb create-table \
+    --table-name terraform-state-locks \
+    --attribute-definitions AttributeName=LockID,AttributeType=S \
+    --key-schema AttributeName=LockID,KeyType=HASH \
+    --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
+```
+
+### 2. Configure Backend
+
+Update `backend.tf` with your S3 bucket and DynamoDB table names:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "your-terraform-state-bucket"
+    key            = "redcap/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-state-locks"
+    encrypt        = true
+  }
+}
+```
+
+### 3. Create Configuration
+
+Copy the example configuration and customize:
+
+```bash
+cp environments/prod/terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` with your specific values:
+
+```hcl
+# Required variables
+ec2_key_name             = "my-redcap-key"
+database_master_password = "your-secure-password"
+ses_username            = "your-ses-username"
+ses_password            = "your-ses-password"
+alb_endpoint_name       = "my-redcap"
+
+# REDCap Community credentials (if using API download)
+redcap_community_username = "your-redcap-username"
+redcap_community_password = "your-redcap-password"
+
+# Optional: Route53 and ACM for custom domain
+use_route53      = true
+use_acm          = true
+hosted_zone_id   = "Z1234567890ABC"
+hosted_zone_name = "example.com"
+domain_name      = "redcap"
+```
+
+### 4. Deploy Infrastructure
+
+```bash
+# Initialize Terraform
+terraform init
+
+# Plan the deployment
+terraform plan
+
+# Apply the configuration
+terraform apply
+```
+
+The deployment typically takes 15-20 minutes.
+
+### 5. Access REDCap
+
+After deployment, find your REDCap URL in the Terraform outputs:
+
+```bash
+terraform output redcap_url
+```
+
+Login with:
+- **Username:** `redcap_admin`
+- **Password:** Your database master password (change immediately after first login)
+
+## Configuration Options
+
+### Environment Variables
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `aws_region` | AWS region for deployment | `us-east-1` | No |
+| `environment` | Environment name | `prod` | No |
+| `ec2_key_name` | EC2 Key Pair name | | Yes |
+| `web_instance_type` | EC2 instance type | `t3.medium` | No |
+| `web_asg_min` | Minimum instances | `2` | No |
+| `web_asg_max` | Maximum instances | `4` | No |
+| `database_instance_type` | RDS instance type | `db.t3.small` | No |
+| `database_master_password` | RDS password | | Yes |
+| `multi_az_database` | Enable Multi-AZ | `false` | No |
+
+### REDCap Download Methods
+
+**Option 1: API Download (Recommended)**
+```hcl
+redcap_download_method = "api"
+redcap_community_username = "your-username"
+redcap_community_password = "your-password"
+redcap_version = "latest"
+```
+
+**Option 2: S3 Upload**
+```hcl
+redcap_download_method = "s3"
+redcap_s3_bucket = "my-redcap-bucket"
+redcap_s3_key = "redcap/redcap14.0.0.zip"
+redcap_s3_bucket_region = "us-east-1"
+```
+
+### Network Configuration
+
+```hcl
+# VPC CIDR blocks
+vpc_cidr = "10.1.0.0/16"
+public_subnet_cidrs = ["10.1.0.0/24", "10.1.1.0/24"]
+app_subnet_cidrs = ["10.1.2.0/24", "10.1.3.0/24"]
+db_subnet_cidrs = ["10.1.4.0/24", "10.1.5.0/24"]
+
+# Access restriction
+access_cidr = "10.0.0.0/8"  # Restrict to your network
+```
+
+## Module Structure
+
+```
+terraform/
+├── main.tf                 # Root module orchestration
+├── variables.tf           # Root variables
+├── outputs.tf            # Root outputs
+├── backend.tf            # S3/DynamoDB backend
+├── modules/
+│   ├── networking/       # VPC, subnets, security groups
+│   ├── database/         # RDS Aurora MySQL
+│   ├── compute/          # ALB, ASG, Launch Template
+│   ├── storage/          # S3 buckets with encryption
+│   ├── dns/              # Route53 and ACM
+│   └── monitoring/       # CloudWatch logs and alarms
+├── environments/
+│   └── prod/
+│       └── terraform.tfvars.example
+└── README.md
+```
+
+## Management and Operations
+
+### Accessing EC2 Instances
+
+Use AWS Systems Manager Session Manager (no SSH required):
+
+```bash
+aws ssm start-session --target i-1234567890abcdef0
+```
+
+### Monitoring
+
+- **CloudWatch Dashboard:** Check the `dashboard_url` output
+- **Log Groups:** Application, Nginx, and PHP-FPM logs
+- **Alarms:** Response time, error rates, health checks
+- **Synthetics:** End-to-end health monitoring
+
+### Scaling
+
+Modify the Auto Scaling Group:
+
+```hcl
+web_asg_min = 3
+web_asg_max = 6
+```
+
+Apply with `terraform apply`.
+
+### Database Management
+
+- **Backups:** Automated daily backups with 7-day retention
+- **Monitoring:** CPU, connections, latency alarms
+- **Encryption:** At rest with KMS, in transit with SSL
+
+### Updates and Maintenance
+
+**Application Updates:**
+1. Update the REDCap version in `terraform.tfvars`
+2. Run `terraform apply`
+3. The Auto Scaling Group will perform rolling updates
+
+**Infrastructure Updates:**
+1. Modify Terraform configuration
+2. Run `terraform plan` to review changes
+3. Run `terraform apply` to implement
+
+## Security Considerations
+
+### Network Security
+- Private subnets for application and database tiers
+- Security groups with least-privilege access
+- VPC Flow Logs for network monitoring
+- WAF recommended for production (not included)
+
+### Data Protection
+- EBS encryption for all volumes
+- RDS encryption at rest with KMS
+- S3 encryption with KMS
+- SSL/TLS for all data in transit
+
+### Access Control
+- IAM roles with minimal required permissions
+- No direct SSH access (use Session Manager)
+- Database credentials in Secrets Manager
+- Application secrets in Parameter Store
+
+### Monitoring and Auditing
+- CloudWatch logs for all services
+- CloudTrail for API auditing (configure separately)
+- VPC Flow Logs for network traffic
+- Application-level error monitoring
+
+## Troubleshooting
+
+### Common Issues
+
+**REDCap Installation Fails:**
+- Check user data logs: `/var/log/user-data.log`
+- Verify database connectivity
+- Ensure REDCap credentials are correct
+
+**Database Connection Issues:**
+- Check security groups allow port 3306
+- Verify database is in available state
+- Check RDS connectivity from app subnets
+
+**SSL Certificate Issues:**
+- Ensure Route53 hosted zone is configured
+- Check ACM certificate validation
+- Verify DNS propagation
+
+### Debugging
+
+```bash
+# Check instance logs
+aws ssm start-session --target i-1234567890abcdef0
+sudo tail -f /var/log/user-data.log
+
+# Check CloudWatch logs
+aws logs describe-log-groups --log-group-name-prefix "/aws/ec2/redcap"
+
+# Check Auto Scaling Group health
+aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names redcap-prod-asg
+```
+
+## Cost Optimization
+
+### Development Environment
+
+```hcl
+# Reduce costs for dev/test
+web_instance_type = "t3.micro"
+web_asg_min = 1
+web_asg_max = 2
+database_instance_type = "db.t3.micro"
+multi_az_database = false
+```
+
+### Production Optimization
+
+- Use Reserved Instances for predictable workloads
+- Enable S3 Intelligent Tiering
+- Monitor CloudWatch costs and set billing alarms
+- Review and optimize instance types based on utilization
+
+## Disaster Recovery
+
+### Backup Strategy
+- **RDS:** Automated backups with point-in-time recovery
+- **S3:** Cross-region replication (configure separately)
+- **Infrastructure:** Terraform state in S3 with versioning
+
+### Recovery Process
+1. Deploy infrastructure in new region using Terraform
+2. Restore RDS from snapshot or backup
+3. Sync S3 data from backup region
+4. Update DNS to point to new environment
+
+## Migration from CloudFormation
+
+If migrating from the existing CloudFormation stack:
+
+1. **Parallel Deployment:** Deploy Terraform infrastructure alongside CloudFormation
+2. **Data Migration:** Export data from old RDS and import to new
+3. **DNS Cutover:** Update Route53 records to point to new ALB
+4. **Cleanup:** Remove CloudFormation stack after validation
+
+## Support and Contributing
+
+For issues and questions:
+1. Check CloudWatch logs and alarms
+2. Review AWS service health dashboards
+3. Consult REDCap community forums
+4. Submit issues via your organization's support process
+
+## License
+
+This Terraform configuration is provided under the same license terms as the original CloudFormation templates.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -125,6 +125,102 @@ Login with:
 - **Username:** `redcap_admin`
 - **Password:** Your database master password (change immediately after first login)
 
+## DNS Configuration
+
+### Option 1: Use Route53 for DNS Management (Recommended)
+
+If you want Terraform to automatically manage your DNS records, configure these variables:
+
+```hcl
+# Enable Route53 and ACM
+use_route53      = true
+use_acm          = true
+
+# Your existing Route53 hosted zone
+hosted_zone_id   = "Z1234567890ABC"  # Found in Route53 console
+hosted_zone_name = "example.com"     # Your domain (e.g., mycompany.org)
+
+# Subdomain for REDCap
+domain_name      = "redcap"          # Creates redcap.example.com
+```
+
+**How it works:**
+1. Terraform creates an ACM certificate for `redcap.example.com`
+2. ACM automatically validates the certificate using DNS validation
+3. Terraform creates Route53 A and AAAA records pointing to the ALB
+4. ALB uses the ACM certificate for HTTPS termination
+
+**Prerequisites:**
+- You must already have a Route53 hosted zone for your domain
+- The hosted zone must be active and receiving queries
+- You need the hosted zone ID (found in Route53 console)
+
+### Option 2: Manual DNS Configuration
+
+If you prefer to manage DNS manually or use a different DNS provider:
+
+```hcl
+# Disable automatic DNS management
+use_route53 = false
+use_acm     = false
+
+# You'll get the ALB DNS name to configure manually
+alb_endpoint_name = "my-redcap-alb"
+```
+
+**Manual steps required:**
+1. After deployment, get the ALB DNS name:
+   ```bash
+   terraform output alb_dns_name
+   # Example output: my-redcap-alb-1234567890.us-east-1.elb.amazonaws.com
+   ```
+
+2. Create DNS records in your DNS provider:
+   ```
+   Type: CNAME
+   Name: redcap.yourcompany.com
+   Value: my-redcap-alb-1234567890.us-east-1.elb.amazonaws.com
+   TTL: 300
+   ```
+
+3. Configure SSL certificate:
+   - Option A: Upload certificate to ACM and update ALB listener
+   - Option B: Use ALB's default certificate (not recommended for production)
+   - Option C: Terminate SSL at application level
+
+### Option 3: Using Existing ACM Certificate
+
+If you already have an ACM certificate:
+
+```hcl
+use_route53 = true   # Still use Route53 for DNS records
+use_acm     = false  # Don't create new certificate
+
+# In the compute module, you would need to modify the configuration
+# to reference your existing certificate ARN
+```
+
+**Note:** This requires modifying the `modules/compute/main.tf` to accept an existing certificate ARN.
+
+### Finding Your Route53 Hosted Zone ID
+
+1. Go to AWS Console → Route53 → Hosted zones
+2. Click on your domain name
+3. Copy the "Hosted zone ID" (starts with Z)
+
+Example:
+```
+Domain: mycompany.org
+Hosted Zone ID: Z2ABC123DEF456GH
+```
+
+Your configuration would be:
+```hcl
+hosted_zone_id   = "Z2ABC123DEF456GH"
+hosted_zone_name = "mycompany.org"
+domain_name      = "redcap"  # Creates redcap.mycompany.org
+```
+
 ## Configuration Options
 
 ### Environment Variables
@@ -238,6 +334,262 @@ Apply with `terraform apply`.
 1. Modify Terraform configuration
 2. Run `terraform plan` to review changes
 3. Run `terraform apply` to implement
+
+## REDCap Code Customization and Updates
+
+### Making Changes to REDCap Code
+
+There are several approaches to customize REDCap code depending on your needs:
+
+#### Option 1: File-Level Customizations (Simple)
+
+For small changes like configuration files or custom hooks:
+
+1. **Access running instance:**
+   ```bash
+   # Find instance ID
+   aws ec2 describe-instances --filters "Name=tag:Name,Values=*redcap*" --query 'Reservations[].Instances[].InstanceId'
+   
+   # Connect via Session Manager
+   aws ssm start-session --target i-1234567890abcdef0
+   ```
+
+2. **Make changes directly:**
+   ```bash
+   sudo su -
+   cd /var/www/html
+   # Make your changes
+   nano redcap/hooks/redcap_connect.php
+   
+   # Restart services
+   systemctl restart nginx php-fpm
+   ```
+
+3. **Persist changes across scaling events:**
+   Create a custom configuration in the user data script or use S3 to store custom files.
+
+#### Option 2: Custom AMI Approach (Recommended for Major Changes)
+
+For significant customizations that need to persist across Auto Scaling events:
+
+1. **Create a custom AMI:**
+   ```bash
+   # Deploy base infrastructure first
+   terraform apply
+   
+   # Connect to instance and make all your customizations
+   aws ssm start-session --target i-1234567890abcdef0
+   
+   # Make your changes, test thoroughly
+   # ...
+   
+   # Create AMI from customized instance
+   aws ec2 create-image \
+     --instance-id i-1234567890abcdef0 \
+     --name "redcap-custom-$(date +%Y%m%d)" \
+     --description "REDCap with custom configurations"
+   ```
+
+2. **Update Launch Template to use custom AMI:**
+   
+   Modify `modules/compute/main.tf`:
+   ```hcl
+   # Replace the data source for AMI
+   data "aws_ami" "custom_redcap" {
+     most_recent = true
+     owners      = ["self"]  # Your account
+     
+     filter {
+       name   = "name"
+       values = ["redcap-custom-*"]
+     }
+   }
+   
+   # Update launch template
+   resource "aws_launch_template" "main" {
+     # ... other configuration ...
+     image_id = data.aws_ami.custom_redcap.id
+     # ... rest of configuration ...
+   }
+   ```
+
+3. **Deploy updated infrastructure:**
+   ```bash
+   terraform apply
+   ```
+
+#### Option 3: S3-Based Configuration Management
+
+For configuration files and small customizations:
+
+1. **Create S3 bucket for customizations:**
+   ```bash
+   aws s3 mb s3://your-redcap-customizations
+   ```
+
+2. **Upload custom files:**
+   ```bash
+   # Upload custom configuration files
+   aws s3 cp custom_config.php s3://your-redcap-customizations/config/
+   aws s3 cp custom_hooks.php s3://your-redcap-customizations/hooks/
+   ```
+
+3. **Modify user data script to download customizations:**
+   
+   Update `modules/compute/userdata.sh`:
+   ```bash
+   # Add after REDCap installation
+   echo "Downloading custom configurations..."
+   aws s3 sync s3://your-redcap-customizations/config/ /var/www/html/redcap/
+   aws s3 sync s3://your-redcap-customizations/hooks/ /var/www/html/redcap/hooks/
+   
+   # Set proper permissions
+   chown -R nginx:nginx /var/www/html
+   ```
+
+#### Option 4: Git-Based Deployment
+
+For version-controlled customizations:
+
+1. **Create Git repository for your REDCap customizations:**
+   ```bash
+   # Structure your repo like:
+   redcap-customizations/
+   ├── config/
+   │   └── custom_settings.php
+   ├── hooks/
+   │   └── redcap_connect.php
+   ├── modules/
+   │   └── custom_module/
+   └── plugins/
+       └── custom_plugin/
+   ```
+
+2. **Modify user data to clone and apply customizations:**
+   ```bash
+   # Add to userdata.sh after REDCap installation
+   cd /tmp
+   git clone https://github.com/yourorg/redcap-customizations.git
+   
+   # Copy customizations
+   cp -r redcap-customizations/config/* /var/www/html/redcap/
+   cp -r redcap-customizations/hooks/* /var/www/html/redcap/hooks/
+   cp -r redcap-customizations/modules/* /var/www/html/redcap/modules/
+   
+   # Set permissions
+   chown -R nginx:nginx /var/www/html
+   ```
+
+### Deploying REDCap Updates
+
+#### Updating REDCap Version
+
+1. **Update version in terraform.tfvars:**
+   ```hcl
+   redcap_version = "14.0.5"  # or "latest"
+   ```
+
+2. **Apply changes:**
+   ```bash
+   terraform apply
+   ```
+
+3. **Auto Scaling Group handles rolling update:**
+   - Creates new instances with updated REDCap version
+   - Waits for health checks to pass
+   - Terminates old instances
+   - Zero-downtime deployment
+
+#### Testing Updates
+
+**Blue-Green Deployment Approach:**
+
+1. **Create a staging environment:**
+   ```bash
+   # Copy production tfvars
+   cp terraform.tfvars terraform-staging.tfvars
+   
+   # Modify for staging
+   sed -i 's/environment = "prod"/environment = "staging"/' terraform-staging.tfvars
+   sed -i 's/domain_name = "redcap"/domain_name = "redcap-staging"/' terraform-staging.tfvars
+   
+   # Deploy staging
+   terraform apply -var-file="terraform-staging.tfvars"
+   ```
+
+2. **Test thoroughly in staging**
+
+3. **Promote to production:**
+   ```bash
+   terraform apply -var-file="terraform.tfvars"
+   ```
+
+#### Database Schema Updates
+
+For REDCap versions that require database changes:
+
+1. **Backup database before update:**
+   ```bash
+   # Create RDS snapshot
+   aws rds create-db-cluster-snapshot \
+     --db-cluster-identifier redcap-prod-aurora-cluster \
+     --db-cluster-snapshot-identifier redcap-backup-$(date +%Y%m%d)
+   ```
+
+2. **Apply infrastructure update**
+
+3. **Monitor for database migration completion:**
+   - Check CloudWatch logs
+   - Verify REDCap admin interface
+   - Test key functionality
+
+#### Rollback Strategy
+
+If an update fails:
+
+1. **Immediate rollback:**
+   ```bash
+   # Revert to previous version
+   git checkout HEAD~1 terraform.tfvars
+   terraform apply
+   ```
+
+2. **Database rollback (if needed):**
+   ```bash
+   # Restore from snapshot
+   aws rds restore-db-cluster-from-snapshot \
+     --db-cluster-identifier redcap-prod-aurora-cluster-restored \
+     --snapshot-identifier redcap-backup-20241201
+   ```
+
+### Best Practices for REDCap Customizations
+
+1. **Version Control:** Always version control your customizations
+2. **Testing:** Test all changes in staging environment first
+3. **Documentation:** Document all customizations and their purposes
+4. **Backup:** Backup database before major updates
+5. **Monitoring:** Monitor application logs during and after updates
+6. **Gradual Rollout:** Use Auto Scaling to gradually replace instances
+
+### Custom Module Development
+
+For developing REDCap External Modules:
+
+1. **Development workflow:**
+   ```bash
+   # Clone your module repo to local development
+   git clone https://github.com/yourorg/redcap-custom-module.git
+   
+   # Make changes locally
+   # Test in staging environment
+   
+   # Deploy to production via S3 or Git integration
+   ```
+
+2. **Production deployment:**
+   - Upload modules to S3 and download via user data
+   - Include in custom AMI
+   - Use REDCap's module repository system
 
 ## Security Considerations
 

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.0"
+  
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  
+  backend "s3" {
+    bucket         = "your-terraform-state-bucket"  # Update with your bucket name
+    key            = "redcap/terraform.tfstate"
+    region         = "us-east-1"                    # Update with your preferred region
+    dynamodb_table = "terraform-state-locks"       # Update with your table name
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  
+  default_tags {
+    tags = {
+      Project     = "REDCap"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  }
+}

--- a/terraform/environments/prod/terraform.tfvars.example
+++ b/terraform/environments/prod/terraform.tfvars.example
@@ -1,0 +1,44 @@
+# AWS Configuration
+aws_region  = "us-east-1"
+environment = "prod"
+
+# EC2 Configuration
+ec2_key_name      = "my-redcap-key"
+web_instance_type = "t3.medium"
+web_asg_min       = 2
+web_asg_max       = 4
+php_version       = "8.1"
+
+# Network Configuration
+access_cidr = "0.0.0.0/0"  # Restrict this to your organization's IP ranges
+
+# Database Configuration
+database_instance_type   = "db.t3.small"
+database_master_password = "your-secure-password-here"  # Use a strong password
+multi_az_database       = true
+
+# DNS and SSL Configuration
+use_route53      = true
+use_acm          = true
+hosted_zone_id   = "Z1234567890ABC"  # Your Route53 hosted zone ID
+hosted_zone_name = "example.com"     # Your domain name
+domain_name      = "redcap"          # Subdomain (will create redcap.example.com)
+alb_endpoint_name = "redcap-prod"
+
+# Email Configuration (SES)
+ses_username = "your-ses-smtp-username"
+ses_password = "your-ses-smtp-password"
+ses_region   = "us-east-1"
+
+# REDCap Application Configuration
+redcap_download_method = "api"  # or "s3"
+
+# If using API method:
+redcap_community_username = "your-redcap-username"
+redcap_community_password = "your-redcap-password"
+redcap_version           = "latest"
+
+# If using S3 method (uncomment and fill in):
+# redcap_s3_bucket        = "my-redcap-source-bucket"
+# redcap_s3_key           = "redcap/redcap14.0.0.zip"
+# redcap_s3_bucket_region = "us-east-1"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,133 @@
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+  common_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    ManagedBy   = "Terraform"
+  }
+}
+
+# Data sources for availability zones
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# VPC and Networking
+module "networking" {
+  source = "./modules/networking"
+
+  name_prefix           = local.name_prefix
+  vpc_cidr             = var.vpc_cidr
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  app_subnet_cidrs     = var.app_subnet_cidrs
+  db_subnet_cidrs      = var.db_subnet_cidrs
+  availability_zones   = data.aws_availability_zones.available.names
+  access_cidr          = var.access_cidr
+  use_acm              = var.use_acm
+  use_route53          = var.use_route53
+
+  tags = local.common_tags
+}
+
+# DNS and SSL Certificate
+module "dns" {
+  source = "./modules/dns"
+  count  = var.use_route53 ? 1 : 0
+
+  domain_name      = var.domain_name
+  hosted_zone_id   = var.hosted_zone_id
+  hosted_zone_name = var.hosted_zone_name
+  use_acm          = var.use_acm
+  alb_dns_name     = module.compute.alb_dns_name
+  alb_zone_id      = module.compute.alb_zone_id
+
+  tags = local.common_tags
+}
+
+# S3 Storage
+module "storage" {
+  source = "./modules/storage"
+
+  name_prefix = local.name_prefix
+  tags        = local.common_tags
+}
+
+# RDS Database
+module "database" {
+  source = "./modules/database"
+
+  name_prefix              = local.name_prefix
+  vpc_id                   = module.networking.vpc_id
+  db_subnet_ids           = module.networking.db_subnet_ids
+  db_security_group_id    = module.networking.db_security_group_id
+  database_instance_type  = var.database_instance_type
+  database_master_password = var.database_master_password
+  multi_az_database       = var.multi_az_database
+
+  tags = local.common_tags
+}
+
+# EC2 Compute Resources
+module "compute" {
+  source = "./modules/compute"
+
+  name_prefix                = local.name_prefix
+  vpc_id                     = module.networking.vpc_id
+  public_subnet_ids          = module.networking.public_subnet_ids
+  app_subnet_ids             = module.networking.app_subnet_ids
+  alb_security_group_id      = module.networking.alb_security_group_id
+  app_security_group_id      = module.networking.app_security_group_id
+  
+  # EC2 Configuration
+  ec2_key_name               = var.ec2_key_name
+  web_instance_type          = var.web_instance_type
+  web_asg_min               = var.web_asg_min
+  web_asg_max               = var.web_asg_max
+  
+  # Application Configuration
+  php_version               = var.php_version
+  database_endpoint         = module.database.cluster_endpoint
+  database_master_password  = var.database_master_password
+  s3_file_bucket           = module.storage.file_repository_bucket_name
+  s3_access_key_id         = module.storage.s3_access_key_id
+  s3_secret_access_key     = module.storage.s3_secret_access_key
+  
+  # SES Configuration
+  ses_username             = var.ses_username
+  ses_password             = var.ses_password
+  ses_region               = var.ses_region
+  
+  # REDCap Configuration
+  redcap_download_method      = var.redcap_download_method
+  redcap_s3_bucket           = var.redcap_s3_bucket
+  redcap_s3_key              = var.redcap_s3_key
+  redcap_s3_bucket_region    = var.redcap_s3_bucket_region
+  redcap_community_username  = var.redcap_community_username
+  redcap_community_password  = var.redcap_community_password
+  redcap_version             = var.redcap_version
+  
+  # SSL Configuration
+  use_acm                   = var.use_acm
+  use_route53               = var.use_route53
+  ssl_certificate_arn       = var.use_acm && var.use_route53 ? module.dns[0].certificate_arn : ""
+  domain_name               = var.domain_name
+  hosted_zone_name          = var.hosted_zone_name
+  alb_endpoint_name         = var.alb_endpoint_name
+
+  tags = local.common_tags
+
+  depends_on = [module.database]
+}
+
+# CloudWatch Monitoring
+module "monitoring" {
+  source = "./modules/monitoring"
+
+  name_prefix            = local.name_prefix
+  auto_scaling_group_name = module.compute.auto_scaling_group_name
+  alb_arn_suffix         = module.compute.alb_arn_suffix
+  target_group_arn_suffix = module.compute.target_group_arn_suffix
+  rds_cluster_id         = module.database.cluster_id
+
+  tags = local.common_tags
+}

--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -1,0 +1,471 @@
+# Data sources
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# Application Load Balancer
+resource "aws_lb" "main" {
+  name               = "${var.name_prefix}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [var.alb_security_group_id]
+  subnets            = var.public_subnet_ids
+
+  enable_deletion_protection = false
+
+  access_logs {
+    bucket  = aws_s3_bucket.alb_logs.bucket
+    prefix  = "alb-logs"
+    enabled = true
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-alb"
+  })
+}
+
+# ALB Target Group
+resource "aws_lb_target_group" "main" {
+  name     = "${var.name_prefix}-tg"
+  port     = var.use_acm ? 443 : 80
+  protocol = var.use_acm ? "HTTPS" : "HTTP"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    interval            = 30
+    matcher             = "200"
+    path                = "/redcap/"
+    port                = "traffic-port"
+    protocol            = var.use_acm ? "HTTPS" : "HTTP"
+    timeout             = 5
+    unhealthy_threshold = 3
+  }
+
+  stickiness {
+    type            = "lb_cookie"
+    cookie_duration = 86400
+    enabled         = true
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-target-group"
+  })
+}
+
+# ALB Listener (HTTP)
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = var.use_acm ? "redirect" : "forward"
+
+    dynamic "redirect" {
+      for_each = var.use_acm ? [1] : []
+      content {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    }
+
+    dynamic "forward" {
+      for_each = var.use_acm ? [] : [1]
+      content {
+        target_group {
+          arn = aws_lb_target_group.main.arn
+        }
+      }
+    }
+  }
+
+  tags = var.tags
+}
+
+# ALB Listener (HTTPS) - conditional
+resource "aws_lb_listener" "https" {
+  count = var.use_acm ? 1 : 0
+
+  load_balancer_arn = aws_lb.main.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn   = var.ssl_certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.main.arn
+  }
+
+  tags = var.tags
+}
+
+# S3 Bucket for ALB access logs
+resource "aws_s3_bucket" "alb_logs" {
+  bucket = "${data.aws_caller_identity.current.account_id}-${var.name_prefix}-alb-logs"
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-alb-logs"
+  })
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+
+  rule {
+    id     = "log_retention"
+    status = "Enabled"
+
+    expiration {
+      days = 90
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_elb_service_account.main.id}:root"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.alb_logs.arn}/alb-logs/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+      },
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "delivery.logs.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.alb_logs.arn}/alb-logs/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl" = "bucket-owner-full-control"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "delivery.logs.amazonaws.com"
+        }
+        Action   = "s3:GetBucketAcl"
+        Resource = aws_s3_bucket.alb_logs.arn
+      }
+    ]
+  })
+}
+
+data "aws_elb_service_account" "main" {}
+
+# IAM Role for EC2 instances
+resource "aws_iam_role" "ec2_role" {
+  name_prefix = "${var.name_prefix}-ec2-role-"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+# IAM policies for EC2 instances
+resource "aws_iam_role_policy_attachment" "ssm_managed_instance_core" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent_server" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_role_policy" "ec2_custom" {
+  name_prefix = "${var.name_prefix}-ec2-custom-"
+  role        = aws_iam_role.ec2_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.s3_file_bucket}",
+          "arn:aws:s3:::${var.s3_file_bucket}/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:PutParameter"
+        ]
+        Resource = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.name_prefix}/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${var.name_prefix}-*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams",
+          "logs:DescribeLogGroups"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "ec2_profile" {
+  name_prefix = "${var.name_prefix}-ec2-profile-"
+  role        = aws_iam_role.ec2_role.name
+
+  tags = var.tags
+}
+
+# User data script for REDCap installation
+locals {
+  user_data = base64encode(templatefile("${path.module}/userdata.sh", {
+    name_prefix                = var.name_prefix
+    aws_region                = data.aws_region.current.name
+    php_version               = var.php_version
+    database_endpoint         = var.database_endpoint
+    database_master_password  = var.database_master_password
+    s3_file_bucket           = var.s3_file_bucket
+    s3_access_key_id         = var.s3_access_key_id
+    s3_secret_access_key     = var.s3_secret_access_key
+    ses_username             = var.ses_username
+    ses_password             = var.ses_password
+    ses_region               = var.ses_region
+    redcap_download_method   = var.redcap_download_method
+    redcap_s3_bucket         = var.redcap_s3_bucket
+    redcap_s3_key            = var.redcap_s3_key
+    redcap_s3_bucket_region  = var.redcap_s3_bucket_region
+    redcap_community_username = var.redcap_community_username
+    redcap_community_password = var.redcap_community_password
+    redcap_version           = var.redcap_version
+    use_acm                  = var.use_acm
+    use_route53              = var.use_route53
+    domain_name              = var.domain_name
+    hosted_zone_name         = var.hosted_zone_name
+    alb_endpoint_name        = var.alb_endpoint_name
+  }))
+}
+
+# Launch Template
+resource "aws_launch_template" "main" {
+  name_prefix   = "${var.name_prefix}-lt-"
+  image_id      = data.aws_ami.amazon_linux.id
+  instance_type = var.web_instance_type
+  key_name      = var.ec2_key_name
+
+  vpc_security_group_ids = [var.app_security_group_id]
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.ec2_profile.name
+  }
+
+  user_data = local.user_data
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      volume_size           = 20
+      volume_type           = "gp3"
+      encrypted             = true
+      delete_on_termination = true
+    }
+  }
+
+  # Additional encrypted volume for logs (HIPAA compliance)
+  block_device_mappings {
+    device_name = "/dev/sdf"
+    ebs {
+      volume_size           = 10
+      volume_type           = "gp3"
+      encrypted             = true
+      delete_on_termination = true
+    }
+  }
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+    http_put_response_hop_limit = 2
+  }
+
+  monitoring {
+    enabled = true
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(var.tags, {
+      Name = "${var.name_prefix}-web-server"
+    })
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags = merge(var.tags, {
+      Name = "${var.name_prefix}-web-server-volume"
+    })
+  }
+
+  tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Auto Scaling Group
+resource "aws_autoscaling_group" "main" {
+  name                = "${var.name_prefix}-asg"
+  vpc_zone_identifier = var.app_subnet_ids
+  target_group_arns   = [aws_lb_target_group.main.arn]
+  health_check_type   = "ELB"
+  health_check_grace_period = 300
+
+  min_size         = var.web_asg_min
+  max_size         = var.web_asg_max
+  desired_capacity = var.web_asg_min
+
+  launch_template {
+    id      = aws_launch_template.main.id
+    version = "$Latest"
+  }
+
+  # Instance refresh for rolling updates
+  instance_refresh {
+    strategy = "Rolling"
+    preferences {
+      min_healthy_percentage = 50
+    }
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${var.name_prefix}-asg"
+    propagate_at_launch = false
+  }
+
+  dynamic "tag" {
+    for_each = var.tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Auto Scaling Policies
+resource "aws_autoscaling_policy" "scale_up" {
+  name                   = "${var.name_prefix}-scale-up"
+  scaling_adjustment     = 1
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = 300
+  autoscaling_group_name = aws_autoscaling_group.main.name
+}
+
+resource "aws_autoscaling_policy" "scale_down" {
+  name                   = "${var.name_prefix}-scale-down"
+  scaling_adjustment     = -1
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = 300
+  autoscaling_group_name = aws_autoscaling_group.main.name
+}
+
+# CloudWatch Alarms for Auto Scaling
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  alarm_name          = "${var.name_prefix}-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "80"
+  alarm_description   = "This metric monitors ec2 cpu utilization"
+  alarm_actions       = [aws_autoscaling_policy.scale_up.arn]
+
+  dimensions = {
+    AutoScalingGroupName = aws_autoscaling_group.main.name
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_low" {
+  alarm_name          = "${var.name_prefix}-cpu-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "20"
+  alarm_description   = "This metric monitors ec2 cpu utilization"
+  alarm_actions       = [aws_autoscaling_policy.scale_down.arn]
+
+  dimensions = {
+    AutoScalingGroupName = aws_autoscaling_group.main.name
+  }
+
+  tags = var.tags
+}

--- a/terraform/modules/compute/outputs.tf
+++ b/terraform/modules/compute/outputs.tf
@@ -1,0 +1,64 @@
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer"
+  value       = aws_lb.main.dns_name
+}
+
+output "alb_zone_id" {
+  description = "Zone ID of the Application Load Balancer"
+  value       = aws_lb.main.zone_id
+}
+
+output "alb_arn" {
+  description = "ARN of the Application Load Balancer"
+  value       = aws_lb.main.arn
+}
+
+output "alb_arn_suffix" {
+  description = "ARN suffix of the Application Load Balancer"
+  value       = aws_lb.main.arn_suffix
+}
+
+output "target_group_arn" {
+  description = "ARN of the target group"
+  value       = aws_lb_target_group.main.arn
+}
+
+output "target_group_arn_suffix" {
+  description = "ARN suffix of the target group"
+  value       = aws_lb_target_group.main.arn_suffix
+}
+
+output "auto_scaling_group_name" {
+  description = "Name of the Auto Scaling Group"
+  value       = aws_autoscaling_group.main.name
+}
+
+output "auto_scaling_group_arn" {
+  description = "ARN of the Auto Scaling Group"
+  value       = aws_autoscaling_group.main.arn
+}
+
+output "launch_template_id" {
+  description = "ID of the Launch Template"
+  value       = aws_launch_template.main.id
+}
+
+output "launch_template_latest_version" {
+  description = "Latest version of the Launch Template"
+  value       = aws_launch_template.main.latest_version
+}
+
+output "iam_role_arn" {
+  description = "ARN of the EC2 IAM role"
+  value       = aws_iam_role.ec2_role.arn
+}
+
+output "iam_instance_profile_name" {
+  description = "Name of the IAM instance profile"
+  value       = aws_iam_instance_profile.ec2_profile.name
+}
+
+output "alb_logs_bucket" {
+  description = "S3 bucket for ALB access logs"
+  value       = aws_s3_bucket.alb_logs.bucket
+}

--- a/terraform/modules/compute/userdata.sh
+++ b/terraform/modules/compute/userdata.sh
@@ -1,0 +1,452 @@
+#!/bin/bash
+
+# REDCap EC2 Instance Setup Script
+# This script installs and configures REDCap on Amazon Linux 2
+
+set -e
+
+# Variables from Terraform
+NAME_PREFIX="${name_prefix}"
+AWS_REGION="${aws_region}"
+PHP_VERSION="${php_version}"
+DB_ENDPOINT="${database_endpoint}"
+DB_PASSWORD="${database_master_password}"
+S3_BUCKET="${s3_file_bucket}"
+S3_ACCESS_KEY="${s3_access_key_id}"
+S3_SECRET_KEY="${s3_secret_access_key}"
+SES_USERNAME="${ses_username}"
+SES_PASSWORD="${ses_password}"
+SES_REGION="${ses_region}"
+REDCAP_METHOD="${redcap_download_method}"
+REDCAP_S3_BUCKET="${redcap_s3_bucket}"
+REDCAP_S3_KEY="${redcap_s3_key}"
+REDCAP_S3_REGION="${redcap_s3_bucket_region}"
+REDCAP_USERNAME="${redcap_community_username}"
+REDCAP_PASSWORD="${redcap_community_password}"
+REDCAP_VERSION="${redcap_version}"
+USE_ACM="${use_acm}"
+USE_ROUTE53="${use_route53}"
+DOMAIN_NAME="${domain_name}"
+HOSTED_ZONE="${hosted_zone_name}"
+ALB_ENDPOINT="${alb_endpoint_name}"
+
+# Logging setup
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+echo "Starting REDCap installation at $(date)"
+
+# Update system
+yum update -y
+
+# Install required packages
+yum install -y \
+    amazon-linux-extras \
+    wget \
+    unzip \
+    mysql \
+    awscli \
+    amazon-cloudwatch-agent \
+    amazon-ssm-agent \
+    postfix \
+    cyrus-sasl-plain
+
+# Configure timezone
+timedatectl set-timezone UTC
+
+# Install and configure Nginx
+amazon-linux-extras install -y nginx1
+systemctl enable nginx
+systemctl start nginx
+
+# Install PHP based on version
+if [[ "$PHP_VERSION" == "8.1" ]]; then
+    amazon-linux-extras install -y php8.1
+elif [[ "$PHP_VERSION" == "8.0" ]]; then
+    amazon-linux-extras install -y php8.0
+else
+    amazon-linux-extras install -y php7.4
+fi
+
+# Install PHP extensions required by REDCap
+yum install -y \
+    php-fpm \
+    php-mysqlnd \
+    php-gd \
+    php-ldap \
+    php-zip \
+    php-curl \
+    php-mbstring \
+    php-xml \
+    php-json \
+    php-openssl
+
+# Start PHP-FPM
+systemctl enable php-fpm
+systemctl start php-fpm
+
+# Configure PHP settings for REDCap
+cat >> /etc/php.ini << 'EOF'
+max_input_vars = 100000
+upload_max_filesize = 32M
+post_max_size = 32M
+memory_limit = 512M
+max_execution_time = 300
+session.gc_maxlifetime = 1440
+date.timezone = "America/New_York"
+EOF
+
+# Set session cookie secure if using HTTPS
+if [[ "$USE_ACM" == "true" ]]; then
+    echo "session.cookie_secure = on" >> /etc/php.ini
+fi
+
+# Mount encrypted volume for logs (HIPAA compliance)
+LOG_DEVICE="/dev/nvme1n1"
+LOG_MOUNT="/var/log/nginx"
+
+if [[ -b "$LOG_DEVICE" ]]; then
+    # Format and mount the encrypted volume
+    mkfs -t ext4 "$LOG_DEVICE"
+    mkdir -p /tmp/nginx_logs_backup
+    cp -a "$LOG_MOUNT"/* /tmp/nginx_logs_backup/ 2>/dev/null || true
+    mount "$LOG_DEVICE" "$LOG_MOUNT"
+    cp -a /tmp/nginx_logs_backup/* "$LOG_MOUNT"/ 2>/dev/null || true
+    rm -rf /tmp/nginx_logs_backup
+    
+    # Add to fstab for persistence
+    echo "$LOG_DEVICE $LOG_MOUNT ext4 defaults,nofail 0 2" >> /etc/fstab
+fi
+
+# Configure Nginx for REDCap
+cat > /etc/nginx/conf.d/redcap.conf << 'EOF'
+server {
+    listen 80;
+    listen 443 ssl http2;
+    server_name _;
+    root /var/www/html;
+    index index.php index.html index.htm;
+
+    # SSL configuration
+    ssl_certificate /etc/ssl/certs/server.crt;
+    ssl_certificate_key /etc/ssl/private/server.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE+AESGCM:ECDHE+AES256:ECDHE+AES128:!aNULL:!MD5:!DSS;
+
+    # Security headers
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+
+    # REDCap specific configuration
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/var/run/php-fpm/www.sock;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+        
+        # Increase timeouts for REDCap
+        fastcgi_read_timeout 300;
+        fastcgi_send_timeout 300;
+    }
+
+    # Deny access to sensitive files
+    location ~ /\. {
+        deny all;
+    }
+    
+    location ~ ~$ {
+        deny all;
+    }
+
+    # REDCap specific denies
+    location ~* \.(log|txt)$ {
+        deny all;
+    }
+}
+EOF
+
+# Generate self-signed certificate for HTTPS
+mkdir -p /etc/ssl/private
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+    -keyout /etc/ssl/private/server.key \
+    -out /etc/ssl/certs/server.crt \
+    -subj "/C=US/ST=State/L=City/O=Organization/OU=OrgUnit/CN=localhost"
+
+chmod 600 /etc/ssl/private/server.key
+
+# Create web directory
+mkdir -p /var/www/html
+chown nginx:nginx /var/www/html
+
+# Download and install REDCap
+cd /tmp
+
+if [[ "$REDCAP_METHOD" == "api" ]]; then
+    echo "Downloading REDCap via API..."
+    curl -o redcap.zip -d "username=$REDCAP_USERNAME&password=$REDCAP_PASSWORD&version=$REDCAP_VERSION&install=1" \
+         -X POST https://redcap.vumc.org/plugins/redcap_consortium/versions.php
+    REDCAP_FILE="redcap.zip"
+else
+    echo "Downloading REDCap from S3..."
+    aws s3 cp "s3://$REDCAP_S3_BUCKET/$REDCAP_S3_KEY" . --region "$REDCAP_S3_REGION"
+    REDCAP_FILE=$(basename "$REDCAP_S3_KEY")
+fi
+
+# Extract REDCap
+unzip -q "$REDCAP_FILE"
+cp -r redcap/* /var/www/html/
+rm -f "$REDCAP_FILE"
+rm -rf redcap
+
+# Set proper permissions
+chown -R nginx:nginx /var/www/html
+find /var/www/html -type d -exec chmod 755 {} \;
+find /var/www/html -type f -exec chmod 644 {} \;
+
+# Configure database connection
+cat > /var/www/html/redcap/database.php << EOF
+<?php
+\$hostname   = '$DB_ENDPOINT';
+\$db         = 'redcap';
+\$username   = 'redcap_user';
+\$password   = '$DB_PASSWORD';
+\$salt       = '';
+
+// Get or create salt from Parameter Store
+\$salt_param = shell_exec("aws ssm get-parameter --name '/$NAME_PREFIX/redcap/salt' --with-decryption --query 'Parameter.Value' --output text --region $AWS_REGION 2>/dev/null");
+if (empty(\$salt_param) || strpos(\$salt_param, 'ParameterNotFound') !== false) {
+    \$salt = bin2hex(random_bytes(16));
+    shell_exec("aws ssm put-parameter --name '/$NAME_PREFIX/redcap/salt' --type 'SecureString' --value '\$salt' --region $AWS_REGION");
+} else {
+    \$salt = trim(\$salt_param);
+}
+EOF
+
+# Wait for database to be available
+echo "Waiting for database to be available..."
+until mysql -h "$DB_ENDPOINT" -u master -p"$DB_PASSWORD" -e "SELECT 1" >/dev/null 2>&1; do
+    echo "Database not ready, waiting..."
+    sleep 10
+done
+
+# Create REDCap database users
+mysql -h "$DB_ENDPOINT" -u master -p"$DB_PASSWORD" -e "
+CREATE USER IF NOT EXISTS 'redcap_user'@'%' IDENTIFIED BY '$DB_PASSWORD';
+GRANT SELECT, INSERT, UPDATE, DELETE ON redcap.* TO 'redcap_user'@'%';
+CREATE USER IF NOT EXISTS 'redcap_user2'@'%' IDENTIFIED BY '$DB_PASSWORD';
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, REFERENCES ON redcap.* TO 'redcap_user2'@'%';
+FLUSH PRIVILEGES;
+"
+
+# Install REDCap database schema (only on first instance)
+LOCK_FILE="/tmp/redcap_install.lock"
+if (
+    flock -n 9 || exit 1
+    
+    # Check if REDCap is already installed
+    if ! mysql -h "$DB_ENDPOINT" -u master -p"$DB_PASSWORD" redcap -e "SELECT * FROM redcap_config LIMIT 1" >/dev/null 2>&1; then
+        echo "Installing REDCap database schema..."
+        
+        # Determine the URL for REDCap install
+        if [[ "$USE_ROUTE53" == "true" ]]; then
+            if [[ "$USE_ACM" == "true" ]]; then
+                REDCAP_URL="https://$DOMAIN_NAME.$HOSTED_ZONE"
+            else
+                REDCAP_URL="http://$DOMAIN_NAME.$HOSTED_ZONE"
+            fi
+        else
+            REDCAP_URL="http://localhost"
+        fi
+        
+        # Wait for nginx to be ready
+        sleep 30
+        
+        # Run REDCap install
+        curl -k -X POST "$REDCAP_URL/install.php" \
+            -d "redcap_csrf_token=" \
+            -d "superusers_only_create_project=0" \
+            -d "superusers_only_move_to_prod=1" \
+            -d "auto_report_stats=1" \
+            -d "bioportal_api_token=" \
+            -d "redcap_base_url=$REDCAP_URL/" \
+            -d "enable_url_shortener=1" \
+            -d "default_datetime_format=D/M/Y_12" \
+            -d "default_number_format_decimal=," \
+            -d "default_number_format_thousands_sep=." \
+            -d "homepage_contact=REDCap Administrator" \
+            -d "homepage_contact_email=admin@example.com" \
+            -d "project_contact_name=REDCap Administrator" \
+            -d "project_contact_email=admin@example.com" \
+            -d "institution=Your Institution" \
+            -d "site_org_type=Research Institution" \
+            -o /tmp/install_output.html
+        
+        # Extract SQL from install output and run it
+        if grep -q "onclick='this.select()'" /tmp/install_output.html; then
+            sed -n "/onclick='this.select()'/,/<\/textarea>/p" /tmp/install_output.html | \
+            sed '1d;$d' > /tmp/redcap_install.sql
+            
+            mysql -h "$DB_ENDPOINT" -u master -p"$DB_PASSWORD" redcap < /tmp/redcap_install.sql
+            
+            # Create admin user and configure S3
+            mysql -h "$DB_ENDPOINT" -u master -p"$DB_PASSWORD" redcap -e "
+                UPDATE redcap_config SET value = 'table' WHERE field_name = 'auth_meth_global';
+                INSERT INTO redcap_user_information (username, user_email, user_firstname, user_lastname, super_user) 
+                VALUES ('redcap_admin', 'admin@example.com', 'REDCap', 'Administrator', '1');
+                INSERT INTO redcap_auth (username, password, legacy_hash, temp_pwd) 
+                VALUES ('redcap_admin', MD5('$DB_PASSWORD'), '1', '1');
+                UPDATE redcap_config SET value = '2' WHERE field_name = 'edoc_storage_option';
+                UPDATE redcap_config SET value = '$S3_BUCKET' WHERE field_name = 'amazon_s3_bucket';
+                UPDATE redcap_config SET value = '$S3_ACCESS_KEY' WHERE field_name = 'amazon_s3_key';
+                UPDATE redcap_config SET value = '$S3_SECRET_KEY' WHERE field_name = 'amazon_s3_secret';
+                UPDATE redcap_config SET value = '$AWS_REGION' WHERE field_name = 'amazon_s3_endpoint';
+                REPLACE INTO redcap_config (field_name, value) VALUES ('aws_quickstart', '1');
+                REPLACE INTO redcap_config (field_name, value) VALUES ('redcap_updates_user', 'redcap_user2');
+                REPLACE INTO redcap_config (field_name, value) VALUES ('redcap_updates_password', '$DB_PASSWORD');
+                REPLACE INTO redcap_config (field_name, value) VALUES ('redcap_updates_password_encrypted', '0');
+            "
+            
+            rm -f /tmp/redcap_install.sql /tmp/install_output.html
+        fi
+    fi
+) 9>"$LOCK_FILE"
+
+# Configure email (Postfix with SES)
+cat > /etc/postfix/main.cf << EOF
+compatibility_level = 2
+queue_directory = /var/spool/postfix
+command_directory = /usr/sbin
+daemon_directory = /usr/libexec/postfix
+data_directory = /var/lib/postfix
+mail_owner = postfix
+inet_interfaces = localhost
+inet_protocols = all
+mydestination = \$myhostname, localhost.\$mydomain, localhost
+unknown_local_recipient_reject_code = 550
+alias_maps = hash:/etc/aliases
+alias_database = hash:/etc/aliases
+debug_peer_level = 2
+debugger_command =
+         PATH=/bin:/usr/bin:/usr/local/bin:/usr/X11R6/bin
+         ddd \$daemon_directory/\$process_name \$process_id & sleep 5
+sendmail_path = /usr/sbin/sendmail.postfix
+newaliases_path = /usr/bin/newaliases.postfix
+mailq_path = /usr/bin/mailq.postfix
+setgid_group = postdrop
+html_directory = no
+manpage_directory = /usr/share/man
+sample_directory = /usr/share/doc/postfix-2.10.1/samples
+readme_directory = /usr/share/doc/postfix-2.10.1/README_FILES
+
+# SES Configuration
+relayhost = [email-smtp.$SES_REGION.amazonaws.com]:587
+smtp_sasl_auth_enable = yes
+smtp_sasl_security_options = noanonymous
+smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
+smtp_use_tls = yes
+smtp_tls_security_level = encrypt
+smtp_tls_note_starttls_offer = yes
+smtp_tls_CAfile = /etc/ssl/certs/ca-bundle.crt
+EOF
+
+# Configure SES credentials
+echo "[email-smtp.$SES_REGION.amazonaws.com]:587 $SES_USERNAME:$SES_PASSWORD" > /etc/postfix/sasl_passwd
+postmap hash:/etc/postfix/sasl_passwd
+chmod 600 /etc/postfix/sasl_passwd*
+
+# Start and enable postfix
+systemctl enable postfix
+systemctl start postfix
+
+# Configure REDCap cron job
+(crontab -l 2>/dev/null; echo "* * * * * /usr/bin/php /var/www/html/redcap/cron.php > /dev/null 2>&1") | crontab -
+
+# Install and configure CloudWatch agent
+cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json << EOF
+{
+    "logs": {
+        "logs_collected": {
+            "files": {
+                "collect_list": [
+                    {
+                        "file_path": "/var/log/nginx/access.log",
+                        "log_group_name": "/aws/ec2/$NAME_PREFIX/nginx/access",
+                        "log_stream_name": "{instance_id}"
+                    },
+                    {
+                        "file_path": "/var/log/nginx/error.log",
+                        "log_group_name": "/aws/ec2/$NAME_PREFIX/nginx/error",
+                        "log_stream_name": "{instance_id}"
+                    },
+                    {
+                        "file_path": "/var/log/php-fpm/www-error.log",
+                        "log_group_name": "/aws/ec2/$NAME_PREFIX/php-fpm/error",
+                        "log_stream_name": "{instance_id}"
+                    }
+                ]
+            }
+        }
+    },
+    "metrics": {
+        "namespace": "REDCap/EC2",
+        "metrics_collected": {
+            "cpu": {
+                "measurement": [
+                    "cpu_usage_idle",
+                    "cpu_usage_iowait",
+                    "cpu_usage_user",
+                    "cpu_usage_system"
+                ],
+                "metrics_collection_interval": 60
+            },
+            "disk": {
+                "measurement": [
+                    "used_percent"
+                ],
+                "metrics_collection_interval": 60,
+                "resources": [
+                    "*"
+                ]
+            },
+            "diskio": {
+                "measurement": [
+                    "io_time"
+                ],
+                "metrics_collection_interval": 60,
+                "resources": [
+                    "*"
+                ]
+            },
+            "mem": {
+                "measurement": [
+                    "mem_used_percent"
+                ],
+                "metrics_collection_interval": 60
+            }
+        }
+    }
+}
+EOF
+
+# Start CloudWatch agent
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+    -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s
+
+# Restart services
+systemctl restart nginx
+systemctl restart php-fpm
+
+# Create marker file to indicate installation is complete
+touch /var/log/redcap-installation-complete
+
+echo "REDCap installation completed at $(date)"
+echo "Access REDCap at: $(if [[ "$USE_ROUTE53" == "true" ]]; then echo "https://$DOMAIN_NAME.$HOSTED_ZONE"; else echo "http://\$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)"; fi)"
+echo "Default admin user: redcap_admin"
+echo "Default admin password: $DB_PASSWORD (change immediately after first login)"

--- a/terraform/modules/compute/variables.tf
+++ b/terraform/modules/compute/variables.tf
@@ -1,0 +1,171 @@
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "List of public subnet IDs for ALB"
+  type        = list(string)
+}
+
+variable "app_subnet_ids" {
+  description = "List of application subnet IDs for EC2 instances"
+  type        = list(string)
+}
+
+variable "alb_security_group_id" {
+  description = "ID of the ALB security group"
+  type        = string
+}
+
+variable "app_security_group_id" {
+  description = "ID of the application security group"
+  type        = string
+}
+
+variable "ec2_key_name" {
+  description = "Name of EC2 Key Pair for SSH access"
+  type        = string
+}
+
+variable "web_instance_type" {
+  description = "EC2 instance type for web servers"
+  type        = string
+}
+
+variable "web_asg_min" {
+  description = "Minimum number of instances in Auto Scaling Group"
+  type        = number
+}
+
+variable "web_asg_max" {
+  description = "Maximum number of instances in Auto Scaling Group"
+  type        = number
+}
+
+variable "php_version" {
+  description = "PHP version to install"
+  type        = string
+}
+
+variable "database_endpoint" {
+  description = "RDS database endpoint"
+  type        = string
+}
+
+variable "database_master_password" {
+  description = "RDS master password"
+  type        = string
+  sensitive   = true
+}
+
+variable "s3_file_bucket" {
+  description = "S3 bucket name for file repository"
+  type        = string
+}
+
+variable "s3_access_key_id" {
+  description = "S3 access key ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "s3_secret_access_key" {
+  description = "S3 secret access key"
+  type        = string
+  sensitive   = true
+}
+
+variable "ses_username" {
+  description = "SES SMTP username"
+  type        = string
+}
+
+variable "ses_password" {
+  description = "SES SMTP password"
+  type        = string
+  sensitive   = true
+}
+
+variable "ses_region" {
+  description = "SES region"
+  type        = string
+}
+
+variable "redcap_download_method" {
+  description = "Method to download REDCap (s3 or api)"
+  type        = string
+}
+
+variable "redcap_s3_bucket" {
+  description = "S3 bucket containing REDCap source"
+  type        = string
+}
+
+variable "redcap_s3_key" {
+  description = "S3 key for REDCap source file"
+  type        = string
+}
+
+variable "redcap_s3_bucket_region" {
+  description = "Region of S3 bucket containing REDCap source"
+  type        = string
+}
+
+variable "redcap_community_username" {
+  description = "REDCap Community username"
+  type        = string
+  sensitive   = true
+}
+
+variable "redcap_community_password" {
+  description = "REDCap Community password"
+  type        = string
+  sensitive   = true
+}
+
+variable "redcap_version" {
+  description = "REDCap version to install"
+  type        = string
+}
+
+variable "use_acm" {
+  description = "Whether to use ACM for SSL certificates"
+  type        = bool
+}
+
+variable "use_route53" {
+  description = "Whether to use Route53 for DNS"
+  type        = bool
+}
+
+variable "ssl_certificate_arn" {
+  description = "ARN of SSL certificate (if using ACM)"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Domain name for REDCap"
+  type        = string
+}
+
+variable "hosted_zone_name" {
+  description = "Route53 hosted zone name"
+  type        = string
+}
+
+variable "alb_endpoint_name" {
+  description = "ALB endpoint name"
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -1,0 +1,202 @@
+# DB Subnet Group
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.name_prefix}-db-subnet-group"
+  subnet_ids = var.db_subnet_ids
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-db-subnet-group"
+  })
+}
+
+# Random password for redcap users
+resource "random_password" "redcap_user_password" {
+  length  = 32
+  special = true
+}
+
+# RDS Aurora Cluster
+resource "aws_rds_cluster" "main" {
+  cluster_identifier      = "${var.name_prefix}-aurora-cluster"
+  engine                 = "aurora-mysql"
+  engine_version         = "5.7.mysql_aurora.2.12.0"
+  database_name          = "redcap"
+  master_username        = "master"
+  master_password        = var.database_master_password
+  
+  backup_retention_period = 7
+  backup_window          = "03:00-04:00"
+  maintenance_window     = "sun:04:00-sun:05:00"
+  
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [var.db_security_group_id]
+  
+  storage_encrypted      = true
+  kms_key_id            = aws_kms_key.rds.arn
+  
+  deletion_protection    = true
+  skip_final_snapshot   = false
+  final_snapshot_identifier = "${var.name_prefix}-aurora-final-snapshot-${formatdate("YYYY-MM-DD-hhmm", timestamp())}"
+  
+  enabled_cloudwatch_logs_exports = ["error", "general", "slowquery"]
+  
+  copy_tags_to_snapshot = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-aurora-cluster"
+  })
+
+  lifecycle {
+    ignore_changes = [final_snapshot_identifier]
+  }
+}
+
+# RDS Aurora Instances
+resource "aws_rds_cluster_instance" "cluster_instances" {
+  count              = var.multi_az_database ? 2 : 1
+  identifier         = "${var.name_prefix}-aurora-instance-${count.index + 1}"
+  cluster_identifier = aws_rds_cluster.main.id
+  instance_class     = var.database_instance_type
+  engine             = aws_rds_cluster.main.engine
+  engine_version     = aws_rds_cluster.main.engine_version
+  
+  publicly_accessible = false
+  
+  performance_insights_enabled = true
+  monitoring_interval         = 60
+  monitoring_role_arn        = aws_iam_role.rds_monitoring.arn
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-aurora-instance-${count.index + 1}"
+  })
+}
+
+# KMS Key for RDS encryption
+resource "aws_kms_key" "rds" {
+  description             = "KMS key for RDS encryption"
+  deletion_window_in_days = 7
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-rds-kms-key"
+  })
+}
+
+resource "aws_kms_alias" "rds" {
+  name          = "alias/${var.name_prefix}-rds"
+  target_key_id = aws_kms_key.rds.key_id
+}
+
+# IAM Role for RDS Enhanced Monitoring
+resource "aws_iam_role" "rds_monitoring" {
+  name_prefix = "${var.name_prefix}-rds-monitoring-"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "monitoring.rds.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "rds_monitoring" {
+  role       = aws_iam_role.rds_monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+# CloudWatch Alarms for RDS
+resource "aws_cloudwatch_metric_alarm" "database_cpu" {
+  alarm_name          = "${var.name_prefix}-rds-cpu-utilization"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "80"
+  alarm_description   = "This metric monitors RDS CPU utilization"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    DBClusterIdentifier = aws_rds_cluster.main.cluster_identifier
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "database_connections" {
+  alarm_name          = "${var.name_prefix}-rds-connection-count"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "50"
+  alarm_description   = "This metric monitors RDS connection count"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    DBClusterIdentifier = aws_rds_cluster.main.cluster_identifier
+  }
+
+  tags = var.tags
+}
+
+# SNS Topic for database alerts
+resource "aws_sns_topic" "alerts" {
+  name = "${var.name_prefix}-database-alerts"
+
+  tags = var.tags
+}
+
+# Store database credentials in AWS Secrets Manager
+resource "aws_secretsmanager_secret" "db_credentials" {
+  name        = "${var.name_prefix}-database-credentials"
+  description = "Database credentials for REDCap"
+
+  tags = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "db_credentials" {
+  secret_id = aws_secretsmanager_secret.db_credentials.id
+  secret_string = jsonencode({
+    master_username = aws_rds_cluster.main.master_username
+    master_password = var.database_master_password
+    redcap_user_password = random_password.redcap_user_password.result
+    endpoint = aws_rds_cluster.main.endpoint
+    port = aws_rds_cluster.main.port
+    database_name = aws_rds_cluster.main.database_name
+  })
+}
+
+# Parameter Store entries for application configuration
+resource "aws_ssm_parameter" "db_endpoint" {
+  name  = "/${var.name_prefix}/database/endpoint"
+  type  = "String"
+  value = aws_rds_cluster.main.endpoint
+
+  tags = var.tags
+}
+
+resource "aws_ssm_parameter" "db_port" {
+  name  = "/${var.name_prefix}/database/port"
+  type  = "String"
+  value = tostring(aws_rds_cluster.main.port)
+
+  tags = var.tags
+}
+
+resource "aws_ssm_parameter" "db_name" {
+  name  = "/${var.name_prefix}/database/name"
+  type  = "String"
+  value = aws_rds_cluster.main.database_name
+
+  tags = var.tags
+}

--- a/terraform/modules/database/outputs.tf
+++ b/terraform/modules/database/outputs.tf
@@ -1,0 +1,51 @@
+output "cluster_id" {
+  description = "RDS cluster identifier"
+  value       = aws_rds_cluster.main.cluster_identifier
+}
+
+output "cluster_endpoint" {
+  description = "RDS cluster endpoint"
+  value       = aws_rds_cluster.main.endpoint
+}
+
+output "cluster_reader_endpoint" {
+  description = "RDS cluster reader endpoint"
+  value       = aws_rds_cluster.main.reader_endpoint
+}
+
+output "cluster_port" {
+  description = "RDS cluster port"
+  value       = aws_rds_cluster.main.port
+}
+
+output "cluster_database_name" {
+  description = "RDS cluster database name"
+  value       = aws_rds_cluster.main.database_name
+}
+
+output "cluster_master_username" {
+  description = "RDS cluster master username"
+  value       = aws_rds_cluster.main.master_username
+  sensitive   = true
+}
+
+output "secrets_manager_arn" {
+  description = "ARN of the Secrets Manager secret containing database credentials"
+  value       = aws_secretsmanager_secret.db_credentials.arn
+}
+
+output "kms_key_id" {
+  description = "KMS key ID used for RDS encryption"
+  value       = aws_kms_key.rds.key_id
+}
+
+output "sns_topic_arn" {
+  description = "ARN of the SNS topic for database alerts"
+  value       = aws_sns_topic.alerts.arn
+}
+
+output "redcap_user_password" {
+  description = "Generated password for REDCap database user"
+  value       = random_password.redcap_user_password.result
+  sensitive   = true
+}

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -1,0 +1,41 @@
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+}
+
+variable "db_subnet_ids" {
+  description = "List of database subnet IDs"
+  type        = list(string)
+}
+
+variable "db_security_group_id" {
+  description = "ID of the database security group"
+  type        = string
+}
+
+variable "database_instance_type" {
+  description = "RDS instance type"
+  type        = string
+}
+
+variable "database_master_password" {
+  description = "Master password for RDS database"
+  type        = string
+  sensitive   = true
+}
+
+variable "multi_az_database" {
+  description = "Deploy RDS in Multi-AZ configuration"
+  type        = bool
+}
+
+variable "tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/dns/main.tf
+++ b/terraform/modules/dns/main.tf
@@ -1,0 +1,122 @@
+# ACM Certificate (if enabled)
+resource "aws_acm_certificate" "main" {
+  count = var.use_acm ? 1 : 0
+
+  domain_name       = "${var.domain_name}.${var.hosted_zone_name}"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.domain_name}.${var.hosted_zone_name}"
+  })
+}
+
+# Route53 record for ACM certificate validation
+resource "aws_route53_record" "cert_validation" {
+  for_each = var.use_acm ? {
+    for dvo in aws_acm_certificate.main[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = var.hosted_zone_id
+}
+
+# ACM certificate validation
+resource "aws_acm_certificate_validation" "main" {
+  count = var.use_acm ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.main[0].arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+
+  timeouts {
+    create = "10m"
+  }
+}
+
+# Route53 A record for ALB
+resource "aws_route53_record" "main" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = var.alb_dns_name
+    zone_id                = var.alb_zone_id
+    evaluate_target_health = true
+  }
+
+  depends_on = [aws_acm_certificate_validation.main]
+}
+
+# Route53 AAAA record for ALB (IPv6 support)
+resource "aws_route53_record" "ipv6" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain_name
+  type    = "AAAA"
+
+  alias {
+    name                   = var.alb_dns_name
+    zone_id                = var.alb_zone_id
+    evaluate_target_health = true
+  }
+
+  depends_on = [aws_acm_certificate_validation.main]
+}
+
+# Route53 health check for monitoring
+resource "aws_route53_health_check" "main" {
+  fqdn                            = "${var.domain_name}.${var.hosted_zone_name}"
+  port                            = var.use_acm ? 443 : 80
+  type                            = var.use_acm ? "HTTPS" : "HTTP"
+  resource_path                   = "/redcap/"
+  failure_threshold               = "3"
+  request_interval                = "30"
+  cloudwatch_alarm_region         = data.aws_region.current.name
+  cloudwatch_alarm_name           = "${var.domain_name}-health-check"
+  insufficient_data_health_status = "Failure"
+
+  tags = merge(var.tags, {
+    Name = "${var.domain_name} Health Check"
+  })
+}
+
+# CloudWatch alarm for Route53 health check
+resource "aws_cloudwatch_metric_alarm" "health_check" {
+  alarm_name          = "${var.domain_name}-health-check-alarm"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = "60"
+  statistic           = "Minimum"
+  threshold           = "1"
+  alarm_description   = "This metric monitors health check status"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.main.id
+  }
+
+  tags = var.tags
+}
+
+# SNS Topic for DNS/health check alerts
+resource "aws_sns_topic" "alerts" {
+  name = "${var.domain_name}-dns-alerts"
+
+  tags = var.tags
+}
+
+# Data source for current region
+data "aws_region" "current" {}

--- a/terraform/modules/dns/outputs.tf
+++ b/terraform/modules/dns/outputs.tf
@@ -1,0 +1,34 @@
+output "certificate_arn" {
+  description = "ARN of the ACM certificate"
+  value       = var.use_acm ? aws_acm_certificate.main[0].arn : null
+}
+
+output "certificate_status" {
+  description = "Status of the ACM certificate"
+  value       = var.use_acm ? aws_acm_certificate.main[0].status : null
+}
+
+output "route53_record_name" {
+  description = "FQDN of the Route53 record"
+  value       = aws_route53_record.main.fqdn
+}
+
+output "route53_record_type" {
+  description = "Type of the Route53 record"
+  value       = aws_route53_record.main.type
+}
+
+output "health_check_id" {
+  description = "ID of the Route53 health check"
+  value       = aws_route53_health_check.main.id
+}
+
+output "health_check_fqdn" {
+  description = "FQDN being monitored by the health check"
+  value       = aws_route53_health_check.main.fqdn
+}
+
+output "sns_topic_arn" {
+  description = "ARN of the SNS topic for DNS alerts"
+  value       = aws_sns_topic.alerts.arn
+}

--- a/terraform/modules/dns/variables.tf
+++ b/terraform/modules/dns/variables.tf
@@ -1,0 +1,35 @@
+variable "domain_name" {
+  description = "Domain name for REDCap application"
+  type        = string
+}
+
+variable "hosted_zone_id" {
+  description = "Route53 hosted zone ID"
+  type        = string
+}
+
+variable "hosted_zone_name" {
+  description = "Route53 hosted zone name"
+  type        = string
+}
+
+variable "use_acm" {
+  description = "Whether to create and use ACM certificate"
+  type        = bool
+}
+
+variable "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer"
+  type        = string
+}
+
+variable "alb_zone_id" {
+  description = "Zone ID of the Application Load Balancer"
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -1,0 +1,319 @@
+# CloudWatch Log Groups
+resource "aws_cloudwatch_log_group" "nginx_access" {
+  name              = "/aws/ec2/${var.name_prefix}/nginx/access"
+  retention_in_days = 30
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-nginx-access-logs"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "nginx_error" {
+  name              = "/aws/ec2/${var.name_prefix}/nginx/error"
+  retention_in_days = 30
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-nginx-error-logs"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "php_fpm_error" {
+  name              = "/aws/ec2/${var.name_prefix}/php-fpm/error"
+  retention_in_days = 30
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-php-fpm-error-logs"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "application" {
+  name              = "/aws/ec2/${var.name_prefix}/application"
+  retention_in_days = 90
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-application-logs"
+  })
+}
+
+# CloudWatch Dashboard
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = "${var.name_prefix}-dashboard"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 12
+        height = 6
+
+        properties = {
+          metrics = [
+            ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", var.alb_arn_suffix],
+            [".", "TargetResponseTime", ".", "."],
+            [".", "HTTPCode_Target_2XX_Count", ".", "."],
+            [".", "HTTPCode_Target_4XX_Count", ".", "."],
+            [".", "HTTPCode_Target_5XX_Count", ".", "."]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = data.aws_region.current.name
+          title   = "ALB Metrics"
+          period  = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 6
+        width  = 12
+        height = 6
+
+        properties = {
+          metrics = [
+            ["AWS/AutoScaling", "GroupDesiredCapacity", "AutoScalingGroupName", var.auto_scaling_group_name],
+            [".", "GroupInServiceInstances", ".", "."],
+            [".", "GroupTotalInstances", ".", "."]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = data.aws_region.current.name
+          title   = "Auto Scaling Group"
+          period  = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 12
+        width  = 12
+        height = 6
+
+        properties = {
+          metrics = [
+            ["AWS/RDS", "CPUUtilization", "DBClusterIdentifier", var.rds_cluster_id],
+            [".", "DatabaseConnections", ".", "."],
+            [".", "ReadLatency", ".", "."],
+            [".", "WriteLatency", ".", "."]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = data.aws_region.current.name
+          title   = "RDS Metrics"
+          period  = 300
+        }
+      },
+      {
+        type   = "log"
+        x      = 0
+        y      = 18
+        width  = 24
+        height = 6
+
+        properties = {
+          query   = "SOURCE '${aws_cloudwatch_log_group.nginx_error.name}'\n| fields @timestamp, @message\n| sort @timestamp desc\n| limit 100"
+          region  = data.aws_region.current.name
+          title   = "Recent Nginx Errors"
+          view    = "table"
+        }
+      }
+    ]
+  })
+}
+
+# CloudWatch Alarms
+resource "aws_cloudwatch_metric_alarm" "alb_response_time" {
+  alarm_name          = "${var.name_prefix}-alb-response-time"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "5"
+  alarm_description   = "This metric monitors ALB response time"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
+  alarm_name          = "${var.name_prefix}-alb-5xx-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "10"
+  alarm_description   = "This metric monitors ALB 5XX errors"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "target_group_unhealthy" {
+  alarm_name          = "${var.name_prefix}-target-group-unhealthy"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "1"
+  alarm_description   = "This metric monitors healthy targets in target group"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    TargetGroup  = var.target_group_arn_suffix
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  tags = var.tags
+}
+
+# Custom metrics for REDCap application
+resource "aws_cloudwatch_log_metric_filter" "redcap_errors" {
+  name           = "${var.name_prefix}-redcap-errors"
+  log_group_name = aws_cloudwatch_log_group.nginx_error.name
+  pattern        = "[timestamp, request_id, level=\"ERROR\", ...]"
+
+  metric_transformation {
+    name      = "REDCapErrors"
+    namespace = "REDCap/Application"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "redcap_error_rate" {
+  alarm_name          = "${var.name_prefix}-redcap-error-rate"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "REDCapErrors"
+  namespace           = "REDCap/Application"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "5"
+  alarm_description   = "This metric monitors REDCap application errors"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  tags = var.tags
+}
+
+# SNS Topic for alerts
+resource "aws_sns_topic" "alerts" {
+  name = "${var.name_prefix}-monitoring-alerts"
+
+  tags = var.tags
+}
+
+# CloudWatch Synthetics canary for end-to-end monitoring
+resource "aws_synthetics_canary" "redcap_health" {
+  name                 = "${var.name_prefix}-health-check"
+  artifact_s3_location = "s3://${aws_s3_bucket.synthetics.bucket}/canary-artifacts"
+  execution_role_arn   = aws_iam_role.synthetics.arn
+  handler              = "redcapHealthCheck.handler"
+  zip_file             = "redcap-health-check.zip"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
+
+  schedule {
+    expression = "rate(5 minutes)"
+  }
+
+  run_config {
+    timeout_in_seconds = 60
+  }
+
+  success_retention_period = 2
+  failure_retention_period = 14
+
+  tags = var.tags
+}
+
+# S3 bucket for Synthetics artifacts
+resource "aws_s3_bucket" "synthetics" {
+  bucket = "${data.aws_caller_identity.current.account_id}-${var.name_prefix}-synthetics"
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-synthetics"
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "synthetics" {
+  bucket = aws_s3_bucket.synthetics.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# IAM role for Synthetics
+resource "aws_iam_role" "synthetics" {
+  name_prefix = "${var.name_prefix}-synthetics-"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "synthetics_execution" {
+  role       = aws_iam_role.synthetics.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchSyntheticsExecutionRolePolicy"
+}
+
+# CloudWatch Log Insights saved queries
+resource "aws_cloudwatch_query_definition" "nginx_access_analysis" {
+  name = "${var.name_prefix}/nginx-access-analysis"
+
+  log_group_names = [
+    aws_cloudwatch_log_group.nginx_access.name
+  ]
+
+  query_string = <<EOF
+fields @timestamp, @message
+| filter @message like /redcap/
+| stats count() by bin(5m)
+| sort @timestamp desc
+EOF
+}
+
+resource "aws_cloudwatch_query_definition" "error_analysis" {
+  name = "${var.name_prefix}/error-analysis"
+
+  log_group_names = [
+    aws_cloudwatch_log_group.nginx_error.name,
+    aws_cloudwatch_log_group.php_fpm_error.name
+  ]
+
+  query_string = <<EOF
+fields @timestamp, @message
+| filter @message like /ERROR/
+| stats count() by bin(1h)
+| sort @timestamp desc
+EOF
+}
+
+# Data sources
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}

--- a/terraform/modules/monitoring/outputs.tf
+++ b/terraform/modules/monitoring/outputs.tf
@@ -1,0 +1,39 @@
+output "log_group_name" {
+  description = "Name of the main application log group"
+  value       = aws_cloudwatch_log_group.application.name
+}
+
+output "dashboard_url" {
+  description = "URL to the CloudWatch dashboard"
+  value       = "https://${data.aws_region.current.name}.console.aws.amazon.com/cloudwatch/home?region=${data.aws_region.current.name}#dashboards:name=${aws_cloudwatch_dashboard.main.dashboard_name}"
+}
+
+output "sns_topic_arn" {
+  description = "ARN of the SNS topic for monitoring alerts"
+  value       = aws_sns_topic.alerts.arn
+}
+
+output "synthetics_canary_name" {
+  description = "Name of the CloudWatch Synthetics canary"
+  value       = aws_synthetics_canary.redcap_health.name
+}
+
+output "log_groups" {
+  description = "Map of log group names"
+  value = {
+    nginx_access   = aws_cloudwatch_log_group.nginx_access.name
+    nginx_error    = aws_cloudwatch_log_group.nginx_error.name
+    php_fpm_error  = aws_cloudwatch_log_group.php_fpm_error.name
+    application    = aws_cloudwatch_log_group.application.name
+  }
+}
+
+output "cloudwatch_alarms" {
+  description = "List of CloudWatch alarm names"
+  value = [
+    aws_cloudwatch_metric_alarm.alb_response_time.alarm_name,
+    aws_cloudwatch_metric_alarm.alb_5xx_errors.alarm_name,
+    aws_cloudwatch_metric_alarm.target_group_unhealthy.alarm_name,
+    aws_cloudwatch_metric_alarm.redcap_error_rate.alarm_name
+  ]
+}

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -1,0 +1,30 @@
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+}
+
+variable "auto_scaling_group_name" {
+  description = "Name of the Auto Scaling Group to monitor"
+  type        = string
+}
+
+variable "alb_arn_suffix" {
+  description = "ARN suffix of the Application Load Balancer"
+  type        = string
+}
+
+variable "target_group_arn_suffix" {
+  description = "ARN suffix of the target group"
+  type        = string
+}
+
+variable "rds_cluster_id" {
+  description = "RDS cluster identifier to monitor"
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -1,0 +1,316 @@
+# VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-vpc"
+  })
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-igw"
+  })
+}
+
+# Public Subnets
+resource "aws_subnet" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-public-subnet-${count.index + 1}"
+    Type = "Public"
+  })
+}
+
+# Application Subnets
+resource "aws_subnet" "app" {
+  count = length(var.app_subnet_cidrs)
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.app_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-app-subnet-${count.index + 1}"
+    Type = "Application"
+  })
+}
+
+# Database Subnets
+resource "aws_subnet" "db" {
+  count = length(var.db_subnet_cidrs)
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.db_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-db-subnet-${count.index + 1}"
+    Type = "Database"
+  })
+}
+
+# Elastic IP for NAT Gateway
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-nat-eip"
+  })
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# NAT Gateway
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-nat-gateway"
+  })
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# Route Tables
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-public-rt"
+  })
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-private-rt"
+  })
+}
+
+# Route Table Associations
+resource "aws_route_table_association" "public" {
+  count = length(aws_subnet.public)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "app" {
+  count = length(aws_subnet.app)
+
+  subnet_id      = aws_subnet.app[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "db" {
+  count = length(aws_subnet.db)
+
+  subnet_id      = aws_subnet.db[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+# Security Groups
+resource "aws_security_group" "alb" {
+  name_prefix = "${var.name_prefix}-alb-"
+  vpc_id      = aws_vpc.main.id
+  description = "Security group for Application Load Balancer"
+
+  # HTTP access
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.access_cidr]
+  }
+
+  # HTTPS access (conditional)
+  dynamic "ingress" {
+    for_each = var.use_acm ? [1] : []
+    content {
+      description = "HTTPS"
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = [var.access_cidr]
+    }
+  }
+
+  # Outbound to application servers
+  egress {
+    description     = "To app servers"
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  egress {
+    description     = "To app servers HTTPS"
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-alb-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group" "app" {
+  name_prefix = "${var.name_prefix}-app-"
+  vpc_id      = aws_vpc.main.id
+  description = "Security group for application servers"
+
+  # HTTP from ALB
+  ingress {
+    description     = "HTTP from ALB"
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  # HTTPS from ALB
+  ingress {
+    description     = "HTTPS from ALB"
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  # SSH access (restricted)
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["127.0.0.1/32"] # Restricted - use Session Manager instead
+  }
+
+  # All outbound traffic
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-app-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group" "db" {
+  name_prefix = "${var.name_prefix}-db-"
+  vpc_id      = aws_vpc.main.id
+  description = "Security group for database"
+
+  # MySQL access from app servers
+  ingress {
+    description     = "MySQL from app servers"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-db-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# VPC Flow Logs for security monitoring
+resource "aws_flow_log" "vpc" {
+  iam_role_arn    = aws_iam_role.flow_log.arn
+  log_destination = aws_cloudwatch_log_group.vpc_flow_log.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.main.id
+}
+
+resource "aws_cloudwatch_log_group" "vpc_flow_log" {
+  name              = "/aws/vpc/flowlogs/${var.name_prefix}"
+  retention_in_days = 30
+
+  tags = var.tags
+}
+
+resource "aws_iam_role" "flow_log" {
+  name_prefix = "${var.name_prefix}-flow-log-"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "vpc-flow-logs.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "flow_log" {
+  name_prefix = "${var.name_prefix}-flow-log-"
+  role        = aws_iam_role.flow_log.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -1,0 +1,59 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "vpc_cidr_block" {
+  description = "CIDR block of the VPC"
+  value       = aws_vpc.main.cidr_block
+}
+
+output "internet_gateway_id" {
+  description = "ID of the Internet Gateway"
+  value       = aws_internet_gateway.main.id
+}
+
+output "nat_gateway_id" {
+  description = "ID of the NAT Gateway"
+  value       = aws_nat_gateway.main.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = aws_subnet.public[*].id
+}
+
+output "app_subnet_ids" {
+  description = "IDs of the application subnets"
+  value       = aws_subnet.app[*].id
+}
+
+output "db_subnet_ids" {
+  description = "IDs of the database subnets"
+  value       = aws_subnet.db[*].id
+}
+
+output "alb_security_group_id" {
+  description = "ID of the ALB security group"
+  value       = aws_security_group.alb.id
+}
+
+output "app_security_group_id" {
+  description = "ID of the application security group"
+  value       = aws_security_group.app.id
+}
+
+output "db_security_group_id" {
+  description = "ID of the database security group"
+  value       = aws_security_group.db.id
+}
+
+output "public_route_table_id" {
+  description = "ID of the public route table"
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_id" {
+  description = "ID of the private route table"
+  value       = aws_route_table.private.id
+}

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -1,0 +1,50 @@
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+}
+
+variable "app_subnet_cidrs" {
+  description = "CIDR blocks for application subnets"
+  type        = list(string)
+}
+
+variable "db_subnet_cidrs" {
+  description = "CIDR blocks for database subnets"
+  type        = list(string)
+}
+
+variable "availability_zones" {
+  description = "List of availability zones"
+  type        = list(string)
+}
+
+variable "access_cidr" {
+  description = "CIDR block for access to REDCap"
+  type        = string
+}
+
+variable "use_acm" {
+  description = "Whether to use ACM for SSL certificates"
+  type        = bool
+}
+
+variable "use_route53" {
+  description = "Whether to use Route53 for DNS"
+  type        = bool
+}
+
+variable "tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -1,0 +1,293 @@
+# Data source for current AWS account ID and region
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# S3 Bucket for REDCap file repository
+resource "aws_s3_bucket" "file_repository" {
+  bucket = "${data.aws_caller_identity.current.account_id}-${var.name_prefix}-redcap-files"
+
+  tags = merge(var.tags, {
+    Name        = "${var.name_prefix}-redcap-files"
+    Purpose     = "REDCap File Repository"
+    Compliance  = "HIPAA"
+  })
+}
+
+# S3 Bucket for backups
+resource "aws_s3_bucket" "backup" {
+  bucket = "${data.aws_caller_identity.current.account_id}-${var.name_prefix}-redcap-backups"
+
+  tags = merge(var.tags, {
+    Name        = "${var.name_prefix}-redcap-backups"
+    Purpose     = "REDCap Backups"
+    Compliance  = "HIPAA"
+  })
+}
+
+# S3 Bucket versioning
+resource "aws_s3_bucket_versioning" "file_repository" {
+  bucket = aws_s3_bucket.file_repository.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "backup" {
+  bucket = aws_s3_bucket.backup.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# S3 Bucket encryption
+resource "aws_s3_bucket_server_side_encryption_configuration" "file_repository" {
+  bucket = aws_s3_bucket.file_repository.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.s3.arn
+      sse_algorithm     = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "backup" {
+  bucket = aws_s3_bucket.backup.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.s3.arn
+      sse_algorithm     = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+# S3 Bucket public access block (HIPAA compliance)
+resource "aws_s3_bucket_public_access_block" "file_repository" {
+  bucket = aws_s3_bucket.file_repository.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "backup" {
+  bucket = aws_s3_bucket.backup.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# S3 Bucket logging
+resource "aws_s3_bucket_logging" "file_repository" {
+  bucket = aws_s3_bucket.file_repository.id
+
+  target_bucket = aws_s3_bucket.backup.id
+  target_prefix = "access-logs/file-repository/"
+}
+
+resource "aws_s3_bucket_logging" "backup" {
+  bucket = aws_s3_bucket.backup.id
+
+  target_bucket = aws_s3_bucket.backup.id
+  target_prefix = "access-logs/backup/"
+}
+
+# S3 Bucket lifecycle configuration
+resource "aws_s3_bucket_lifecycle_configuration" "file_repository" {
+  bucket = aws_s3_bucket.file_repository.id
+
+  rule {
+    id     = "transition_to_ia"
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "STANDARD_IA"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 90
+      storage_class   = "GLACIER"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 365
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "backup" {
+  bucket = aws_s3_bucket.backup.id
+
+  rule {
+    id     = "backup_lifecycle"
+    status = "Enabled"
+
+    transition {
+      days          = 7
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+
+    transition {
+      days          = 365
+      storage_class = "DEEP_ARCHIVE"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+  }
+}
+
+# KMS Key for S3 encryption
+resource "aws_kms_key" "s3" {
+  description             = "KMS key for S3 bucket encryption"
+  deletion_window_in_days = 7
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-s3-kms-key"
+  })
+}
+
+resource "aws_kms_alias" "s3" {
+  name          = "alias/${var.name_prefix}-s3"
+  target_key_id = aws_kms_key.s3.key_id
+}
+
+# IAM User for S3 access (for REDCap application)
+resource "aws_iam_user" "s3_user" {
+  name = "${var.name_prefix}-s3-user"
+  path = "/"
+
+  tags = var.tags
+}
+
+resource "aws_iam_access_key" "s3_user" {
+  user = aws_iam_user.s3_user.name
+}
+
+# IAM Policy for S3 access
+resource "aws_iam_user_policy" "s3_user" {
+  name = "${var.name_prefix}-s3-policy"
+  user = aws_iam_user.s3_user.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:GetObjectVersion",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          aws_s3_bucket.file_repository.arn,
+          "${aws_s3_bucket.file_repository.arn}/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey"
+        ]
+        Resource = aws_kms_key.s3.arn
+      }
+    ]
+  })
+}
+
+# S3 Bucket notification for monitoring
+resource "aws_s3_bucket_notification" "file_repository" {
+  bucket = aws_s3_bucket.file_repository.id
+
+  cloudwatch_configuration {
+    cloudwatch_configuration_id = "file-upload-monitoring"
+    filter_prefix              = ""
+    filter_suffix              = ""
+    events = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+  }
+}
+
+# CloudWatch metric filter for S3 access logs
+resource "aws_cloudwatch_log_group" "s3_access" {
+  name              = "/aws/s3/${var.name_prefix}/access-logs"
+  retention_in_days = 90
+
+  tags = var.tags
+}
+
+# S3 Bucket policy for additional security
+resource "aws_s3_bucket_policy" "file_repository" {
+  bucket = aws_s3_bucket.file_repository.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureConnections"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.file_repository.arn,
+          "${aws_s3_bucket.file_repository.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_policy" "backup" {
+  bucket = aws_s3_bucket.backup.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureConnections"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.backup.arn,
+          "${aws_s3_bucket.backup.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/modules/storage/outputs.tf
+++ b/terraform/modules/storage/outputs.tf
@@ -1,0 +1,46 @@
+output "file_repository_bucket_name" {
+  description = "Name of the S3 bucket for REDCap file repository"
+  value       = aws_s3_bucket.file_repository.bucket
+}
+
+output "file_repository_bucket_arn" {
+  description = "ARN of the S3 bucket for REDCap file repository"
+  value       = aws_s3_bucket.file_repository.arn
+}
+
+output "backup_bucket_name" {
+  description = "Name of the S3 bucket for backups"
+  value       = aws_s3_bucket.backup.bucket
+}
+
+output "backup_bucket_arn" {
+  description = "ARN of the S3 bucket for backups"
+  value       = aws_s3_bucket.backup.arn
+}
+
+output "s3_access_key_id" {
+  description = "Access key ID for S3 user"
+  value       = aws_iam_access_key.s3_user.id
+  sensitive   = true
+}
+
+output "s3_secret_access_key" {
+  description = "Secret access key for S3 user"
+  value       = aws_iam_access_key.s3_user.secret
+  sensitive   = true
+}
+
+output "s3_user_arn" {
+  description = "ARN of the S3 IAM user"
+  value       = aws_iam_user.s3_user.arn
+}
+
+output "kms_key_id" {
+  description = "KMS key ID used for S3 encryption"
+  value       = aws_kms_key.s3.key_id
+}
+
+output "kms_key_arn" {
+  description = "KMS key ARN used for S3 encryption"
+  value       = aws_kms_key.s3.arn
+}

--- a/terraform/modules/storage/variables.tf
+++ b/terraform/modules/storage/variables.tf
@@ -1,0 +1,10 @@
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,68 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = module.networking.vpc_id
+}
+
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer"
+  value       = module.compute.alb_dns_name
+}
+
+output "alb_zone_id" {
+  description = "Zone ID of the Application Load Balancer"
+  value       = module.compute.alb_zone_id
+}
+
+output "database_endpoint" {
+  description = "RDS cluster endpoint"
+  value       = module.database.cluster_endpoint
+  sensitive   = true
+}
+
+output "database_port" {
+  description = "RDS cluster port"
+  value       = module.database.cluster_port
+}
+
+output "s3_file_repository_bucket" {
+  description = "S3 bucket for REDCap file repository"
+  value       = module.storage.file_repository_bucket_name
+}
+
+output "s3_backup_bucket" {
+  description = "S3 bucket for backups"
+  value       = module.storage.backup_bucket_name
+}
+
+output "redcap_url" {
+  description = "URL to access REDCap application"
+  value = var.use_route53 ? (
+    var.use_acm ? 
+      "https://${var.domain_name}.${var.hosted_zone_name}" : 
+      "http://${var.domain_name}.${var.hosted_zone_name}"
+  ) : (
+    var.use_acm ? 
+      "https://${module.compute.alb_dns_name}" : 
+      "http://${module.compute.alb_dns_name}"
+  )
+}
+
+output "ssl_certificate_arn" {
+  description = "ARN of the SSL certificate (if created)"
+  value       = var.use_route53 && var.use_acm ? module.dns[0].certificate_arn : null
+}
+
+output "auto_scaling_group_name" {
+  description = "Name of the Auto Scaling Group"
+  value       = module.compute.auto_scaling_group_name
+}
+
+output "launch_template_id" {
+  description = "ID of the EC2 Launch Template"
+  value       = module.compute.launch_template_id
+}
+
+output "cloudwatch_log_group_name" {
+  description = "Name of the CloudWatch Log Group"
+  value       = module.monitoring.log_group_name
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,240 @@
+variable "aws_region" {
+  description = "AWS region for deployment"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+  default     = "prod"
+}
+
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+  default     = "redcap"
+}
+
+# EC2 Configuration
+variable "ec2_key_name" {
+  description = "Name of an EC2 KeyPair for SSH access"
+  type        = string
+}
+
+variable "web_instance_type" {
+  description = "EC2 instance type for web servers"
+  type        = string
+  default     = "t3.medium"
+  validation {
+    condition = can(regex("^(t3|m5|c5|r5)\\.(nano|micro|small|medium|large|xlarge|2xlarge|4xlarge|8xlarge|12xlarge|16xlarge|24xlarge)$", var.web_instance_type))
+    error_message = "Instance type must be a valid EC2 instance type."
+  }
+}
+
+variable "web_asg_min" {
+  description = "Minimum number of EC2 instances in Auto Scaling Group"
+  type        = number
+  default     = 2
+  validation {
+    condition     = var.web_asg_min >= 1 && var.web_asg_min <= 10
+    error_message = "Minimum instances must be between 1 and 10."
+  }
+}
+
+variable "web_asg_max" {
+  description = "Maximum number of EC2 instances in Auto Scaling Group"
+  type        = number
+  default     = 4
+  validation {
+    condition     = var.web_asg_max >= 1 && var.web_asg_max <= 30
+    error_message = "Maximum instances must be between 1 and 30."
+  }
+}
+
+variable "php_version" {
+  description = "PHP version to install"
+  type        = string
+  default     = "8.1"
+  validation {
+    condition     = contains(["7.4", "8.0", "8.1"], var.php_version)
+    error_message = "PHP version must be 7.4, 8.0, or 8.1."
+  }
+}
+
+# Network Configuration
+variable "access_cidr" {
+  description = "CIDR block for access to REDCap (0.0.0.0/0 for anywhere)"
+  type        = string
+  default     = "0.0.0.0/0"
+  validation {
+    condition     = can(cidrhost(var.access_cidr, 0))
+    error_message = "Access CIDR must be a valid CIDR block."
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.1.0.0/16"
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+  default     = ["10.1.0.0/24", "10.1.1.0/24"]
+}
+
+variable "app_subnet_cidrs" {
+  description = "CIDR blocks for application subnets"
+  type        = list(string)
+  default     = ["10.1.2.0/24", "10.1.3.0/24"]
+}
+
+variable "db_subnet_cidrs" {
+  description = "CIDR blocks for database subnets"
+  type        = list(string)
+  default     = ["10.1.4.0/24", "10.1.5.0/24"]
+}
+
+# Database Configuration
+variable "database_instance_type" {
+  description = "RDS instance type"
+  type        = string
+  default     = "db.t3.small"
+  validation {
+    condition = can(regex("^db\\.(t3|r5)\\.(small|medium|large|xlarge|2xlarge|4xlarge|8xlarge|16xlarge|24xlarge)$", var.database_instance_type))
+    error_message = "Database instance type must be a valid RDS instance type."
+  }
+}
+
+variable "database_master_password" {
+  description = "Master password for RDS database"
+  type        = string
+  sensitive   = true
+  validation {
+    condition     = length(var.database_master_password) >= 8 && length(var.database_master_password) <= 41
+    error_message = "Database password must be between 8 and 41 characters."
+  }
+}
+
+variable "multi_az_database" {
+  description = "Deploy RDS in Multi-AZ configuration"
+  type        = bool
+  default     = false
+}
+
+# DNS and SSL Configuration
+variable "use_route53" {
+  description = "Use Route53 for DNS"
+  type        = bool
+  default     = false
+}
+
+variable "use_acm" {
+  description = "Use AWS Certificate Manager for SSL"
+  type        = bool
+  default     = false
+}
+
+variable "hosted_zone_id" {
+  description = "Route53 hosted zone ID"
+  type        = string
+  default     = ""
+}
+
+variable "hosted_zone_name" {
+  description = "Route53 hosted zone name"
+  type        = string
+  default     = ""
+}
+
+variable "domain_name" {
+  description = "Domain name for REDCap"
+  type        = string
+  default     = ""
+}
+
+variable "alb_endpoint_name" {
+  description = "Name for ALB endpoint"
+  type        = string
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]+$", var.alb_endpoint_name))
+    error_message = "ALB endpoint name must contain only letters, numbers, and hyphens."
+  }
+}
+
+# Email Configuration (SES)
+variable "ses_username" {
+  description = "SES SMTP username"
+  type        = string
+}
+
+variable "ses_password" {
+  description = "SES SMTP password"
+  type        = string
+  sensitive   = true
+}
+
+variable "ses_region" {
+  description = "SES region"
+  type        = string
+  default     = "us-east-1"
+  validation {
+    condition = contains([
+      "us-east-1", "us-east-2", "us-west-1", "us-west-2", "eu-west-1", 
+      "eu-west-2", "eu-central-1", "ap-south-1", "ap-southeast-1", 
+      "ap-southeast-2", "ap-northeast-1", "ap-northeast-2", "ca-central-1"
+    ], var.ses_region)
+    error_message = "SES region must be a valid SES-enabled region."
+  }
+}
+
+# REDCap Application Configuration
+variable "redcap_download_method" {
+  description = "How to obtain REDCap source (s3 or api)"
+  type        = string
+  default     = "api"
+  validation {
+    condition     = contains(["s3", "api"], var.redcap_download_method)
+    error_message = "REDCap download method must be 's3' or 'api'."
+  }
+}
+
+variable "redcap_s3_bucket" {
+  description = "S3 bucket containing REDCap source (if using s3 method)"
+  type        = string
+  default     = ""
+}
+
+variable "redcap_s3_key" {
+  description = "S3 key for REDCap source file (if using s3 method)"
+  type        = string
+  default     = ""
+}
+
+variable "redcap_s3_bucket_region" {
+  description = "Region of S3 bucket containing REDCap source"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "redcap_community_username" {
+  description = "REDCap Community username (if using api method)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "redcap_community_password" {
+  description = "REDCap Community password (if using api method)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "redcap_version" {
+  description = "REDCap version to install (if using api method)"
+  type        = string
+  default     = "latest"
+}


### PR DESCRIPTION
Convert CloudFormation to a modular Terraform stack for a HIPAA-compliant REDCap application using an EC2-based architecture.

The existing CloudFormation stack is being migrated to Terraform to enhance repeatability and management. The EC2-based architecture was chosen over Elastic Beanstalk or ECS Fargate to provide greater control and cost-effectiveness for an application with a few hundred users, while maintaining all HIPAA compliance features. This new setup is designed to run in parallel with the existing CloudFormation deployment for a smooth transition.